### PR TITLE
Simple fix and copy details button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Trello Card Numbers
 This chrome extension adds card numbers to trello cards to help when viewing boards with a group of people. Trello actually includes card numbers but hides them by default.
+
 ## Overview
 This extension does the following:
 - Reveals card numbers on cards themselves
@@ -12,5 +13,8 @@ This extension does the following:
 ## Credit
 This project was based off the widely available bookmarklet for trello numbers found [here](http://goo.gl/yKfjV).
 
-### Chrome Web Store
+## Chrome Web Store
 Install it [here](https://chrome.google.com/webstore/detail/trello-card-numbers/kadpkdielickimifpinkknemjdipghaf?hl=en&gl=US).
+
+## Safari Port 
+A safari port of this extension can be found [here](https://github.com/fourpi/trello-card-numbers-safari).

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Trello Card Numbers",
   "description": "Adds card numbers to a variety of places when using Trello.",
-  "version": "2.2.4",
+  "version": "2.2.5",
 
   "options_ui": {
     "page": "options.html",

--- a/options.html
+++ b/options.html
@@ -25,6 +25,10 @@
       <td class="align-right"><label><h3><strong>Bold Card Numbers: </strong></h3></label></td>
       <td class="align-left"><input type="checkbox" id="bold" value="true"><br/></td>
     </tr>
+    <tr>
+      <td class="align-right"><label><h3><strong>Show copy link: </strong></h3></label></td>
+      <td class="align-left"><input type="checkbox" id="show-copy" value="true"><br/></td>
+    </tr>
   </table>
 
   <div id="status"></div>

--- a/options.html
+++ b/options.html
@@ -27,7 +27,7 @@
     </tr>
     <tr>
       <td class="align-right"><label><h3><strong>Show copy link: </strong></h3></label></td>
-      <td class="align-left"><input type="checkbox" id="show-copy" value="true"><br/></td>
+      <td class="align-left"><input type="checkbox" id="show-copy" value="false"><br/></td>
     </tr>
   </table>
 

--- a/options.js
+++ b/options.js
@@ -1,9 +1,11 @@
 function save_options() {
     var bold = document.getElementById('bold').checked;
     var color = document.getElementById('id-color').value;
+    var copy = document.getElementById('show-copy').checked;
     chrome.storage.sync.set({
         boldId: bold,
-        idColor: color
+        idColor: color,
+        showCopy: copy
     }, function() {
         window.close();
     });
@@ -11,15 +13,18 @@ function save_options() {
 
 function reset_defaults() {
     document.getElementById('bold').checked = false;
+    document.getElementById('show-copy').checked = true;
     document.getElementById('id-color').color.fromString("#000000");
 }
 
 function restore_options() {
     chrome.storage.sync.get({
         boldId: false,
+        showCopy: true,
         idColor: "000000"
     }, function(items) {
         document.getElementById('bold').checked = items.boldId;
+        document.getElementById('show-copy').checked = items.showCopy;
         document.getElementById('id-color').color.fromString(items.idColor);
     });
 }

--- a/options.js
+++ b/options.js
@@ -13,14 +13,14 @@ function save_options() {
 
 function reset_defaults() {
     document.getElementById('bold').checked = false;
-    document.getElementById('show-copy').checked = true;
+    document.getElementById('show-copy').checked = false;
     document.getElementById('id-color').color.fromString("#000000");
 }
 
 function restore_options() {
     chrome.storage.sync.get({
         boldId: false,
-        showCopy: true,
+        showCopy: false,
         idColor: "000000"
     }, function(items) {
         document.getElementById('bold').checked = items.boldId;

--- a/trello-card-numbers.js
+++ b/trello-card-numbers.js
@@ -228,7 +228,7 @@ window.addEventListener('load', function() {
     var pageUrl = document.location.href;
     var matches = pageUrl.match(cardUrlRegex);
     if (matches != null && matches.length !== 0) {
-        var num = getCardNumberFromUrl(pageUrl);
+        var num = '#' + getCardNumberFromUrl(pageUrl);
         addNumberToLightboxWhenReady(num);
     }
 }, false);

--- a/trello-card-numbers.js
+++ b/trello-card-numbers.js
@@ -161,11 +161,38 @@ function addNumberToLightboxWhenReady(cardNumber) {
             h2.style.marginRight = '10px';
             h2.innerHTML = '<span>' + cardNumber + '</span>';
             obj.insertBefore(h2, obj.lastChild);
+
+
+            chrome.storage.sync.get(function(items) {
+                // undefined if not set. Assume enabled by default.
+                if (items.showCopy == undefined || items.showCopy == true) {
+                    var copyButton = getByClass("button-link js-copy-card")[0];
+
+                    var copyDetailsButton = document.createElement('a');
+                    copyDetailsButton.className = 'button-link';
+                    copyDetailsButton.href = '#';
+                    copyDetailsButton.onclick = function() {
+                        var cardText = getByClass('js-card-detail-title-input')[0].value;
+                
+                        // Ew....
+                        // Source http://stackoverflow.com/a/18455088
+                        var copyFrom = document.createElement("textarea");
+                        copyFrom.textContent = cardNumber.trim() + ", " + cardText; // Unsure if its ok to refer to cardNumber from params.
+                        document.body.appendChild(copyFrom);
+                        copyFrom.select();
+                        document.execCommand('copy');
+                        document.body.removeChild(copyFrom);
+                    };
+                    copyDetailsButton.innerHTML = '<span class="icon-sm icon-card"></span>&nbsp;Copy details</a>';
+                    copyButton.parentNode.insertBefore(copyDetailsButton, copyButton.nextSibling); 
+                }
+            });       
         }
     }, function (err) {
         null;
     });
 }
+
 
 window.addEventListener('load', function() {
     var showListNumbers = addClassWithDisplay(LIST_NUM_CARDS_CLASS, TCN_INLINE_BLOCK, 'inline-block', null);

--- a/trello-card-numbers.js
+++ b/trello-card-numbers.js
@@ -164,8 +164,7 @@ function addNumberToLightboxWhenReady(cardNumber) {
 
 
             chrome.storage.sync.get(function(items) {
-                // undefined if not set. Assume enabled by default.
-                if (items.showCopy == undefined || items.showCopy == true) {
+                if (items.showCopy == true) {
                     var copyButton = getByClass("button-link js-copy-card")[0];
 
                     var copyDetailsButton = document.createElement('a');


### PR DESCRIPTION
Fixed an issue where # would not display in front of card number if loading from URL (dbc70dd)

Copy details button copies "#<cardNum>, <cardTitle>" into your clipboard. Useful if you do commits based on Trello cards and you want to have your card number in your commit. Displays under "Copy" under more actions section. Unsure what the card icon should be, looks odd being the same as copy... (62a7546)

And other commit was just to update version number.