### PR TITLE
New options page layout, with “Copy details” message customization

### DIFF
--- a/options.html
+++ b/options.html
@@ -8,26 +8,32 @@
       height: 150px;
       margin-left: auto;
       margin-right: auto;
+      margin-bottom: 30px;
     }
     .align-left { text-align: left; }
     .align-right { text-align: right; }
-
+    .align-center { text-align: center; }
   </style>
 </head>
 
 <body>
   <table>
     <tr>
-      <td class="align-right"><label><h3><strong>Card Id Color: </strong></h3></label></td>
-      <td class="align-left"><input id="id-color" class="color"><br/></td>
+      <td class="align-right"><label><h3><strong>Card Id Color:</strong></h3></label></td>
+      <td class="align-left"><input id="id-color" class="color"></td>
     </tr>
     <tr>
       <td class="align-right"><label><h3><strong>Bold Card Numbers: </strong></h3></label></td>
-      <td class="align-left"><input type="checkbox" id="bold" value="true"><br/></td>
+      <td class="align-left"><input type="checkbox" id="bold" value="true"></td>
     </tr>
     <tr>
       <td class="align-right"><label><h3><strong>Show copy link: </strong></h3></label></td>
-      <td class="align-left"><input type="checkbox" id="show-copy" value="false"><br/></td>
+      <td class="align-left"><input type="checkbox" id="show-copy" value="false"></td>
+    </tr>
+    <tr>
+      <td class="align-center" colspan="2">
+        <input id="copy-prefix" value="" size="3" class="align-right">#000<input id="copy-sep" value=", " size="1">Example title<input id="copy-suffix" value="" size="1">
+      </td>
     </tr>
   </table>
 

--- a/options.html
+++ b/options.html
@@ -3,39 +3,48 @@
 <head>
   <title>My Test Extension Options</title>
   <style>
-    table {
+    #copy-prefix {
+      text-align: right;
+    }
+
+    #options {
       width: 250px;
       height: 150px;
-      margin-left: auto;
-      margin-right: auto;
-      margin-bottom: 30px;
+      margin: 30px auto 20px auto;
     }
-    .align-left { text-align: left; }
-    .align-right { text-align: right; }
-    .align-center { text-align: center; }
+    
+    .option-line {
+      margin-bottom: 20px;
+    }
+    
+    .option-details {
+      margin-top: 10px;
+      padding-left: 20px;
+    }
+    
+    label {
+      font-size: 1.2em;
+      font-weight: bold;
+      margin-bottom: 0.8em;
+    }
   </style>
 </head>
 
 <body>
-  <table>
-    <tr>
-      <td class="align-right"><label><h3><strong>Card Id Color:</strong></h3></label></td>
-      <td class="align-left"><input id="id-color" class="color"></td>
-    </tr>
-    <tr>
-      <td class="align-right"><label><h3><strong>Bold Card Numbers: </strong></h3></label></td>
-      <td class="align-left"><input type="checkbox" id="bold" value="true"></td>
-    </tr>
-    <tr>
-      <td class="align-right"><label><h3><strong>Show copy link: </strong></h3></label></td>
-      <td class="align-left"><input type="checkbox" id="show-copy" value="false"></td>
-    </tr>
-    <tr>
-      <td class="align-center" colspan="2">
-        <input id="copy-prefix" value="" size="3" class="align-right">#000<input id="copy-sep" value=", " size="1">Example title<input id="copy-suffix" value="" size="1">
-      </td>
-    </tr>
-  </table>
+  <div id="options">
+    <div class="option-line">
+      <label for="id-color">Card Id Color:</label> <input id="id-color" class="color">
+    </div>
+    <div class="option-line">
+      <label><input type="checkbox" id="bold" value="false"> Bold Card Numbers</label>
+    </div>
+    <div class="option-line">
+      <label><input type="checkbox" id="show-copy" value="false"> Show "Copy details" button:</label>
+      <div class="option-details">
+        <input id="copy-prefix" value="" size="4" class="align-right"> #000 <input id="copy-sep" value=", " size="1"> Example title <input id="copy-suffix" value="" size="1">
+      </div>
+    </div>
+  </div>
 
   <div id="status"></div>
   <button id="save">Save and Exit</button>

--- a/options.js
+++ b/options.js
@@ -1,11 +1,21 @@
+const DEFAULT_COPY_PREFIX = ""
+const DEFAULT_COPY_SEP = ", "
+const DEFAULT_COPY_SUFFIX = ""
+
 function save_options() {
     var bold = document.getElementById('bold').checked;
     var color = document.getElementById('id-color').value;
     var copy = document.getElementById('show-copy').checked;
+    var pref = document.getElementById('copy-prefix').value;
+    var sep = document.getElementById('copy-sep').value;
+    var suff = document.getElementById('copy-suffix').value;
     chrome.storage.sync.set({
         boldId: bold,
         idColor: color,
-        showCopy: copy
+        showCopy: copy,
+        copyPrefix: pref,
+        copySep: sep,
+        copySuffix: suff
     }, function() {
         window.close();
     });
@@ -15,17 +25,26 @@ function reset_defaults() {
     document.getElementById('bold').checked = false;
     document.getElementById('show-copy').checked = false;
     document.getElementById('id-color').color.fromString("#000000");
+    document.getElementById('copy-prefix').value = DEFAULT_COPY_PREFIX;
+    document.getElementById('copy-sep').value = DEFAULT_COPY_SEP;
+    document.getElementById('copy-suffix').value = DEFAULT_COPY_SUFFIX;
 }
 
 function restore_options() {
     chrome.storage.sync.get({
         boldId: false,
         showCopy: false,
-        idColor: "000000"
+        idColor: "000000",
+        copyPrefix: DEFAULT_COPY_PREFIX,
+        copySep: DEFAULT_COPY_SEP,
+        copySuffix: DEFAULT_COPY_SUFFIX
     }, function(items) {
         document.getElementById('bold').checked = items.boldId;
         document.getElementById('show-copy').checked = items.showCopy;
         document.getElementById('id-color').color.fromString(items.idColor);
+	    document.getElementById('copy-prefix').value = items.copyPrefix;
+	    document.getElementById('copy-sep').value = items.copySep;
+	    document.getElementById('copy-suffix').value = items.copySuffix;
     });
 }
 

--- a/options.js
+++ b/options.js
@@ -1,3 +1,6 @@
+const DEFAULT_COLOR = "000000"
+const DEFAULT_BOLD = false
+const DEFAULT_SHOW_COPY = false
 const DEFAULT_COPY_PREFIX = ""
 const DEFAULT_COPY_SEP = ", "
 const DEFAULT_COPY_SUFFIX = ""
@@ -22,9 +25,9 @@ function save_options() {
 }
 
 function reset_defaults() {
-    document.getElementById('bold').checked = false;
-    document.getElementById('show-copy').checked = false;
-    document.getElementById('id-color').color.fromString("#000000");
+    document.getElementById('bold').checked = DEFAULT_BOLD;
+    document.getElementById('show-copy').checked = DEFAULT_SHOW_COPY;
+    document.getElementById('id-color').color.fromString("#"+DEFAULT_COLOR);
     document.getElementById('copy-prefix').value = DEFAULT_COPY_PREFIX;
     document.getElementById('copy-sep').value = DEFAULT_COPY_SEP;
     document.getElementById('copy-suffix').value = DEFAULT_COPY_SUFFIX;
@@ -32,9 +35,9 @@ function reset_defaults() {
 
 function restore_options() {
     chrome.storage.sync.get({
-        boldId: false,
-        showCopy: false,
-        idColor: "000000",
+        boldId: DEFAULT_BOLD,
+        showCopy: DEFAULT_SHOW_COPY,
+        idColor: DEFAULT_COLOR,
         copyPrefix: DEFAULT_COPY_PREFIX,
         copySep: DEFAULT_COPY_SEP,
         copySuffix: DEFAULT_COPY_SUFFIX

--- a/trello-card-numbers.js
+++ b/trello-card-numbers.js
@@ -191,7 +191,8 @@ function addNumberToLightboxWhenReady(cardNumber) {
                         // Ew....
                         // Source http://stackoverflow.com/a/18455088
                         var copyFrom = document.createElement("textarea");
-                        copyFrom.textContent = cardNumber.trim() + ", " + cardText; // Unsure if its ok to refer to cardNumber from params.
+                        // Unsure if its ok to refer to cardNumber from params.
+                        copyFrom.textContent = items.copyPrefix + cardNumber.trim() + items.copySep + cardText + items.copySuffix;
                         document.body.appendChild(copyFrom);
                         copyFrom.select();
                         document.execCommand('copy');


### PR DESCRIPTION
![screen shot 2017-09-26 at 14 29 42](https://user-images.githubusercontent.com/9969/30863403-de33a292-a2c8-11e7-9c15-79886a016bf7.png)

**Reorganize options form layout**

- Place checkboxes on the left of the label
- Link or scope labels to their inputs so that clicking on the labels
  activates the input

**Allow to customize the "Copy Details" message**

- Define your own prefix, separator and suffix for the details message.
- The default message remains as before: #000, Example title

**Internals**

- Add constants for all default options
- Use divs instead of a table to layout the options, since it’s no longer using a "label on the left, value on the right" layout
