### PR TITLE
querySelectorAll not finding proper links

### DIFF
--- a/trello-card-numbers.js
+++ b/trello-card-numbers.js
@@ -234,7 +234,7 @@ window.addEventListener('load', function() {
                         showCardIds();
                         var card = node.querySelectorAll(CARD_LINK_QUERY_SELECTOR)[0];
                         var duplicateCheck = node.querySelectorAll(CARD_SHORT_ID_SELECTOR).length > 0;
-                        if (card.getAttribute('href') == undefined && !duplicateCheck) {
+                        if (card && card.getAttribute('href') == undefined && !duplicateCheck) {
                             hrefReady(card).then(function(href) {
                                 var cardTitle = card.innerHTML;
                                 var shortId = document.createElement('span');


### PR DESCRIPTION
Error when not being able to load cards via the `a` tag selector. The only `a` tag it finds in the troubleshooting guide. In the case of it not being able to load the resources, the selector returns null. Checking getAttribute on an undefined variable throws an error.

`Your browser was unable to load all of Trello's resources. They may have been blocked by your firewall, proxy or browser configuration.`